### PR TITLE
Get rid of Psr prefix. Move exceptions to subfolder.

### DIFF
--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrConnectionFactory');
+
+if (\false) {
+    interface ConnectionFactory extends PsrConnectionFactory
+    {
+    }
+}

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrConsumer');
+
+if (\false) {
+    interface Consumer extends PsrConsumer
+    {
+    }
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrContext');
+
+if (\false) {
+    interface Context extends PsrContext
+    {
+    }
+}

--- a/src/DeliveryDelayNotSupportedException.php
+++ b/src/DeliveryDelayNotSupportedException.php
@@ -19,3 +19,5 @@ class DeliveryDelayNotSupportedException extends Exception
         return new static('The provider does not support delivery delay feature', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\DeliveryDelayNotSupportedException', 'Interop\Queue\Exception\DeliveryDelayNotSupportedException', false);

--- a/src/DeliveryDelayNotSupportedException.php
+++ b/src/DeliveryDelayNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class DeliveryDelayNotSupportedException extends Exception
 {
     /**

--- a/src/Destination.php
+++ b/src/Destination.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrDestination');
+
+if (\false) {
+    interface Destination extends PsrDestination
+    {
+    }
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ *
  * This is the root class of all transport's exceptions.
  *
  * @see https://docs.oracle.com/javaee/7/api/javax/jms/JMSException.html
@@ -11,3 +13,5 @@ namespace Interop\Queue;
 class Exception extends \Exception implements ExceptionInterface
 {
 }
+
+class_alias('Interop\Queue\Exception', 'Interop\Queue\Exception\Exception', false);

--- a/src/Exception/DeliveryDelayNotSupportedException.php
+++ b/src/Exception/DeliveryDelayNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\DeliveryDelayNotSupportedException');
+
+if (\false) {
+    class DeliveryDelayNotSupportedException extends \Interop\Queue\DeliveryDelayNotSupportedException
+    {
+    }
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\Exception');
+
+if (\false) {
+    class Exception extends \Interop\Queue\Exception
+    {
+    }
+}

--- a/src/Exception/InvalidDestinationException.php
+++ b/src/Exception/InvalidDestinationException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\InvalidDestinationException');
+
+if (\false) {
+    class InvalidDestinationException extends \Interop\Queue\InvalidDestinationException
+    {
+    }
+}

--- a/src/Exception/InvalidMessageException.php
+++ b/src/Exception/InvalidMessageException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\InvalidMessageException');
+
+if (\false) {
+    class InvalidMessageException extends \Interop\Queue\InvalidMessageException
+    {
+    }
+}

--- a/src/Exception/PriorityNotSupportedException.php
+++ b/src/Exception/PriorityNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\PriorityNotSupportedException');
+
+if (\false) {
+    class PriorityNotSupportedException extends \Interop\Queue\PriorityNotSupportedException
+    {
+    }
+}

--- a/src/Exception/PurgeQueueNotSupportedException.php
+++ b/src/Exception/PurgeQueueNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\PurgeQueueNotSupportedException');
+
+if (\false) {
+    class PurgeQueueNotSupportedException extends \Interop\Queue\PurgeQueueNotSupportedException
+    {
+    }
+}

--- a/src/Exception/SubscriptionConsumerNotSupportedException.php
+++ b/src/Exception/SubscriptionConsumerNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\SubscriptionConsumerNotSupportedException');
+
+if (\false) {
+    class SubscriptionConsumerNotSupportedException extends \Interop\Queue\SubscriptionConsumerNotSupportedException
+    {
+    }
+}

--- a/src/Exception/TemporaryQueueNotSupportedException.php
+++ b/src/Exception/TemporaryQueueNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\TemporaryQueueNotSupportedException');
+
+if (\false) {
+    class TemporaryQueueNotSupportedException extends \Interop\Queue\TemporaryQueueNotSupportedException
+    {
+    }
+}

--- a/src/Exception/TimeToLiveNotSupportedException.php
+++ b/src/Exception/TimeToLiveNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue\Exception;
+
+class_exists('Interop\Queue\TimeToLiveNotSupportedException');
+
+if (\false) {
+    class TimeToLiveNotSupportedException extends \Interop\Queue\TimeToLiveNotSupportedException
+    {
+    }
+}

--- a/src/InvalidDestinationException.php
+++ b/src/InvalidDestinationException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class InvalidDestinationException extends Exception
 {
     /**
@@ -22,3 +25,6 @@ class InvalidDestinationException extends Exception
         }
     }
 }
+
+class_alias('Interop\Queue\InvalidDestinationException', 'Interop\Queue\Exception\InvalidDestinationException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/InvalidMessageException.php
+++ b/src/InvalidMessageException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class InvalidMessageException extends Exception
 {
     /**
@@ -22,3 +25,6 @@ class InvalidMessageException extends Exception
         }
     }
 }
+
+class_alias('Interop\Queue\InvalidMessageException', 'Interop\Queue\Exception\InvalidMessageException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrMessage');
+
+if (\false) {
+    interface Message extends PsrMessage
+    {
+    }
+}

--- a/src/PriorityNotSupportedException.php
+++ b/src/PriorityNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class PriorityNotSupportedException extends Exception
 {
     /**
@@ -16,3 +19,6 @@ class PriorityNotSupportedException extends Exception
         return new static('The provider does not support priority feature', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\PriorityNotSupportedException', 'Interop\Queue\Exception\PriorityNotSupportedException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrProcessor');
+
+if (\false) {
+    interface Processor extends PsrProcessor
+    {
+    }
+}

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrProducer');
+
+if (\false) {
+    interface Producer extends PsrProducer
+    {
+    }
+}

--- a/src/PsrConnectionFactory.php
+++ b/src/PsrConnectionFactory.php
@@ -3,7 +3,13 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ */
 interface PsrConnectionFactory
 {
     public function createContext(): PsrContext;
 }
+
+class_alias('Interop\Queue\PsrConnectionFactory', 'Interop\Queue\ConnectionFactory', false);
+class_exists('Interop\Queue\PsrContext');

--- a/src/PsrConsumer.php
+++ b/src/PsrConsumer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ *
  * A client uses a MessageConsumer object to receive messages from a destination.
  * A MessageConsumer object is created by passing a Destination object
  * to a message-consumer creation method supplied by a session.
@@ -41,3 +43,7 @@ interface PsrConsumer
      */
     public function reject(PsrMessage $message, bool $requeue = false): void;
 }
+
+class_alias('Interop\Queue\PsrConsumer', 'Interop\Queue\Consumer', false);
+class_exists('Interop\Queue\PsrQueue');
+class_exists('Interop\Queue\PsrMessage');

--- a/src/PsrContext.php
+++ b/src/PsrContext.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ */
 interface PsrContext
 {
     public function createMessage(string $body = '', array $properties = [], array $headers = []): PsrMessage;
@@ -36,3 +39,12 @@ interface PsrContext
 
     public function close(): void;
 }
+
+class_alias('Interop\Queue\PsrContext', 'Interop\Queue\Context', false);
+class_exists('Interop\Queue\PsrQueue');
+class_exists('Interop\Queue\PsrTopic');
+class_exists('Interop\Queue\PsrDestination');
+class_exists('Interop\Queue\PsrMessage');
+class_exists('Interop\Queue\PsrProducer');
+class_exists('Interop\Queue\PsrConsumer');
+class_exists('Interop\Queue\PsrSubscriptionConsumer');

--- a/src/PsrDestination.php
+++ b/src/PsrDestination.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ *
  * A Destination object encapsulates a provider-specific address.
  * The transport API does not define a standard address syntax.
  * Although a standard address syntax was considered,
@@ -18,3 +20,5 @@ namespace Interop\Queue;
 interface PsrDestination
 {
 }
+
+class_alias('Interop\Queue\PsrDestination', 'Interop\Queue\Destination', false);

--- a/src/PsrMessage.php
+++ b/src/PsrMessage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ *
  * The Message interface is the root interface of all transport messages.
  * Most message-oriented middleware (MOM) products
  * treat messages as lightweight entities that consist of a header and a payload.
@@ -115,3 +117,5 @@ interface PsrMessage
      */
     public function getReplyTo(): ?string;
 }
+
+class_alias('Interop\Queue\PsrMessage', 'Interop\Queue\Message', false);

--- a/src/PsrProcessor.php
+++ b/src/PsrProcessor.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ */
 interface PsrProcessor
 {
     /**
@@ -35,3 +38,7 @@ interface PsrProcessor
      */
     public function process(PsrMessage $message, PsrContext $context);
 }
+
+class_alias('Interop\Queue\PsrProcessor', 'Interop\Queue\Processor', false);
+class_exists('Interop\Queue\PsrContext');
+class_exists('Interop\Queue\PsrMessage');

--- a/src/PsrProducer.php
+++ b/src/PsrProducer.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ */
 interface PsrProducer
 {
     /**
@@ -68,3 +71,7 @@ interface PsrProducer
      */
     public function getTimeToLive(): ?int;
 }
+
+class_alias('Interop\Queue\PsrProducer', 'Interop\Queue\Producer', false);
+class_exists('Interop\Queue\PsrDestination');
+class_exists('Interop\Queue\PsrMessage');

--- a/src/PsrQueue.php
+++ b/src/PsrQueue.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ *
  * A Queue object encapsulates a provider-specific queue name.
  * It is the way a client specifies the identity of a queue to transport methods.
  * For those methods that use a Destination as a parameter, a Queue object used as an argument.
@@ -17,3 +19,6 @@ interface PsrQueue extends PsrDestination
      */
     public function getQueueName(): string;
 }
+
+class_alias('Interop\Queue\PsrQueue', 'Interop\Queue\Queue', false);
+class_exists('Interop\Queue\PsrDestination');

--- a/src/PsrSubscriptionConsumer.php
+++ b/src/PsrSubscriptionConsumer.php
@@ -1,6 +1,11 @@
 <?php
+declare(strict_types=1);
+
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ */
 interface PsrSubscriptionConsumer
 {
     /**
@@ -24,3 +29,7 @@ interface PsrSubscriptionConsumer
 
     public function unsubscribeAll(): void;
 }
+
+
+class_alias('Interop\Queue\PsrSubscriptionConsumer', 'Interop\Queue\SubscriptionConsumer', false);
+class_exists('Interop\Queue\PsrConsumer');

--- a/src/PsrTopic.php
+++ b/src/PsrTopic.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Interop\Queue;
 
 /**
+ * @deprecated will be removed in later versions. use one without Psr prefix.
+ *
  * A Topic object encapsulates a provider-specific topic name.
  * It is the way a client specifies the identity of a topic to transport methods.
  * For those methods that use a Destination as a parameter, a Topic object may used as an argument.
@@ -17,3 +19,6 @@ interface PsrTopic extends PsrDestination
      */
     public function getTopicName(): string;
 }
+
+class_alias('Interop\Queue\PsrTopic', 'Interop\Queue\Topic', false);
+class_exists('Interop\Queue\PsrDestination');

--- a/src/PurgeQueueNotSupportedException.php
+++ b/src/PurgeQueueNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class PurgeQueueNotSupportedException extends Exception
 {
     /**
@@ -16,3 +19,6 @@ class PurgeQueueNotSupportedException extends Exception
         return new static('The provider does not support purge queue.', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\PurgeQueueNotSupportedException', 'Interop\Queue\Exception\PurgeQueueNotSupportedException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrQueue');
+
+if (\false) {
+    interface Queue extends PsrQueue
+    {
+    }
+}

--- a/src/SubscriptionConsumer.php
+++ b/src/SubscriptionConsumer.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrSubscriptionConsumer');
+
+if (\false) {
+    interface SubscriptionConsumer extends PsrSubscriptionConsumer
+    {
+    }
+}

--- a/src/SubscriptionConsumerNotSupportedException.php
+++ b/src/SubscriptionConsumerNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class SubscriptionConsumerNotSupportedException extends Exception
 {
     /**
@@ -16,3 +19,6 @@ class SubscriptionConsumerNotSupportedException extends Exception
         return new static('The provider does not support subscription consumer.', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\SubscriptionConsumerNotSupportedException', 'Interop\Queue\Exception\SubscriptionConsumerNotSupportedException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/TemporaryQueueNotSupportedException.php
+++ b/src/TemporaryQueueNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class TemporaryQueueNotSupportedException extends Exception
 {
     /**
@@ -16,3 +19,6 @@ class TemporaryQueueNotSupportedException extends Exception
         return new static('The provider does not support temporary queue feature', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\TemporaryQueueNotSupportedException', 'Interop\Queue\Exception\TemporaryQueueNotSupportedException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/TimeToLiveNotSupportedException.php
+++ b/src/TimeToLiveNotSupportedException.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Interop\Queue;
 
+/**
+ * @deprecated will be removed in later versions. use one from Interop\Queue\Exception namespace.
+ */
 class TimeToLiveNotSupportedException extends Exception
 {
     /**
@@ -16,3 +19,6 @@ class TimeToLiveNotSupportedException extends Exception
         return new static('The provider does not support time to live feature', $code, $previous);
     }
 }
+
+class_alias('Interop\Queue\TimeToLiveNotSupportedException', 'Interop\Queue\Exception\TimeToLiveNotSupportedException', false);
+class_exists('Interop\Queue\Exception');

--- a/src/Topic.php
+++ b/src/Topic.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Interop\Queue;
+
+class_exists('Interop\Queue\PsrTopic');
+
+if (\false) {
+    interface Topic extends PsrTopic
+    {
+    }
+}


### PR DESCRIPTION
For example:

```
\Interop\Queue\PsrContext -> \Interop\Queue\Context
\Interop\Queue\PsrQueue -> \Interop\Queue\Queue
```

```
\Interop\Queue\InvalidMessageException -> \Interop\Queue\Exception\InvalidMessageException
```