### PR TITLE
Correct var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ use Enqueue\Fs\FsConnectionFactory;
 
 $context = (new FsConnectionFactory())->createContext();
 
-$consumer = $consumer->createConsumer($context->createQueue('aQueue'));
+$consumer = $context->createConsumer($context->createQueue('aQueue'));
 
 $timeout = 5000; // 5sec
 if ($message = $consumer->receive($timeout)) {


### PR DESCRIPTION
The non-existing at the time consumer cannot create a consumer. The context probably does.