### PR TITLE
Explicit nullable types

### DIFF
--- a/src/Exception/DeliveryDelayNotSupportedException.php
+++ b/src/Exception/DeliveryDelayNotSupportedException.php
@@ -7,11 +7,11 @@ class DeliveryDelayNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support delivery delay feature', $code, $previous);
     }

--- a/src/Exception/PriorityNotSupportedException.php
+++ b/src/Exception/PriorityNotSupportedException.php
@@ -7,11 +7,11 @@ class PriorityNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support priority feature', $code, $previous);
     }

--- a/src/Exception/PurgeQueueNotSupportedException.php
+++ b/src/Exception/PurgeQueueNotSupportedException.php
@@ -7,11 +7,11 @@ class PurgeQueueNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support purge queue.', $code, $previous);
     }

--- a/src/Exception/SubscriptionConsumerNotSupportedException.php
+++ b/src/Exception/SubscriptionConsumerNotSupportedException.php
@@ -7,11 +7,11 @@ class SubscriptionConsumerNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support subscription consumer.', $code, $previous);
     }

--- a/src/Exception/TemporaryQueueNotSupportedException.php
+++ b/src/Exception/TemporaryQueueNotSupportedException.php
@@ -7,11 +7,11 @@ class TemporaryQueueNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support temporary queue feature', $code, $previous);
     }

--- a/src/Exception/TimeToLiveNotSupportedException.php
+++ b/src/Exception/TimeToLiveNotSupportedException.php
@@ -7,11 +7,11 @@ class TimeToLiveNotSupportedException extends Exception
 {
     /**
      * @param int $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      *
      * @return static
      */
-    public static function providerDoestNotSupportIt(int $code = 0, \Throwable $previous = null): self
+    public static function providerDoestNotSupportIt(int $code = 0, ?\Throwable $previous = null): self
     {
         return new static('The provider does not support time to live feature', $code, $previous);
     }

--- a/src/Impl/ConsumerVisibilityTimeoutTrait.php
+++ b/src/Impl/ConsumerVisibilityTimeoutTrait.php
@@ -23,7 +23,7 @@ trait ConsumerVisibilityTimeoutTrait
      * The duration (in seconds) that the received messages are hidden from subsequent retrieve
      * requests after being retrieved by a ReceiveMessage request.
      */
-    public function setVisibilityTimeout(int $visibilityTimeout = null): void
+    public function setVisibilityTimeout(?int $visibilityTimeout = null): void
     {
         $this->visibilityTimeout = $visibilityTimeout;
     }

--- a/src/Impl/MessageTrait.php
+++ b/src/Impl/MessageTrait.php
@@ -97,7 +97,7 @@ trait MessageTrait
         return $this->redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -107,7 +107,7 @@ trait MessageTrait
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -124,12 +124,12 @@ trait MessageTrait
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -57,7 +57,7 @@ interface Message
      * A client can use the correlation header field to link one message with another.
      * A typical use is to link a response message with its request message.
      */
-    public function setCorrelationId(string $correlationId = null): void;
+    public function setCorrelationId(?string $correlationId = null): void;
 
     /**
      * Gets the correlation ID for the message.
@@ -71,7 +71,7 @@ interface Message
      * Providers set this field when a message is sent.
      * This method can be used to change the value for a message that has been received.
      */
-    public function setMessageId(string $messageId = null): void;
+    public function setMessageId(?string $messageId = null): void;
 
     /**
      * Gets the message Id.
@@ -94,7 +94,7 @@ interface Message
      * Providers set this field when a message is sent.
      * This method can be used to change the value for a message that has been received.
      */
-    public function setTimestamp(int $timestamp = null): void;
+    public function setTimestamp(?int $timestamp = null): void;
 
     /**
      * Sets the destination to which a reply to this message should be sent.
@@ -108,7 +108,7 @@ interface Message
      * The client can use the CorrelationID header field for this purpose.
 
      */
-    public function setReplyTo(string $replyTo = null): void;
+    public function setReplyTo(?string $replyTo = null): void;
 
     /**
      * Gets the destination to which a reply to this message should be sent.

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,7 +26,7 @@ interface Producer
      *
      * @throws DeliveryDelayNotSupportedException if producer does not support delivery delay feature
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): self;
+    public function setDeliveryDelay(?int $deliveryDelay = null): self;
 
     /**
      * Gets the minimum length of time in milliseconds that must elapse after a message is sent before the provider may deliver the message to a consumer.
@@ -45,7 +45,7 @@ interface Producer
      *
      * @throws PriorityNotSupportedException if producer does not support priority feature
      */
-    public function setPriority(int $priority = null): self;
+    public function setPriority(?int $priority = null): self;
 
     /**
      * Return the priority of messages that are sent using this Producer
@@ -65,7 +65,7 @@ interface Producer
      *
      * @throws TimeToLiveNotSupportedException if producer does not support time to live feature
      */
-    public function setTimeToLive(int $timeToLive = null): self;
+    public function setTimeToLive(?int $timeToLive = null): self;
 
     /**
      * Returns the time to live of messages that are sent using this JMSProducer.


### PR DESCRIPTION
Resolves PHP 8.4 deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated